### PR TITLE
Tweak Beispiel zu Wichtige Hinweise

### DIFF
--- a/Wichtige-Hinweise-zum-Mikrochip.md
+++ b/Wichtige-Hinweise-zum-Mikrochip.md
@@ -37,19 +37,17 @@ der Betriebsvariablen reichen, wodurch man dann Fehlfunktionen erzeugt.
 Daher ist dieser Ansatz für unsere Chips *nicht* empfohlen.
 
 Arbeiten Sie sicherheitshalber lieber mit Allokationen, deren Größe zum Zeitpunkt
-des Compilerens bekannt sind, also mit
+des Compilerens bekannt sind wie folgt.
 
 ```c
-/* Die Aufgabe muß auch für Größe 0 wohldefiniert sein! */
-void aufgabe_der_groesse_M(int r[], int M) {
+/* Die Aufgabe muß auch für Größe 0 wohldefiniert sein. */
+void aufgabe_der_groesse_M(int r[], unsigned char M) {
     unsigned char j;
     unsigned long microseconds = micros();
 
     /* loese die Aufgabe der Groesse M */
-    if (M > 0) {  // Prüfe, ob M größer 0 ist, um Fehler zu vermeiden
-        for (j = 0; j < M; ++j) {
-            r[j] = j + 17;
-        }
+    for (j = 0; j < M; ++j) {
+        r[j] = j + 17;
     }
 
     microseconds = micros() - microseconds;
@@ -62,7 +60,7 @@ int ri[N];
 
 /* Aufsetzen der Testreihe beispielsweise eingefügt am Ende von setup() */
 unsigned char Mi;
-for (Mi = 0; Mi < N; ++Mi) {
+for (Mi = 0; Mi <= N; ++Mi) {
     aufgabe_der_groesse_M(ri, Mi);
 }
 ```


### PR DESCRIPTION
Das Beispiel ist für M=0 wohldefiniert, daher wird der Test in der Funktion nicht benötigt.

Weitere kleine Korrekturen.